### PR TITLE
Automate publishing to NPM registry checking pkg version

### DIFF
--- a/.github/willPublish.js
+++ b/.github/willPublish.js
@@ -1,0 +1,132 @@
+const exec = require('child_process').exec;
+
+/**
+ * Execute a simple shell command.
+ * @param {String} cmd
+ * @return {Object} { stdout: String, stderr: String }
+ */
+async function shell(cmd) {
+  return new Promise(function (resolve, reject) {
+    exec(cmd, (err, stdout, stderr) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve({ stdout, stderr });
+      }
+    });
+  });
+}
+
+/**
+ * Extract package name and version from package.json file.
+ * @return {Object} [name: String, version: String]
+ */
+async function getProjectNameAndVersion() {
+  const pkgJson = require('../package.json');
+  return [pkgJson.name.trim(), pkgJson.version.trim()];
+}
+
+/**
+ * Get published version of a package in the NPM remote registry.
+ * @param {String} packageName
+ * @return {Object} { ok: boolean, msg: String, version: String }
+ */
+async function getPublishedVersion(packageName) {
+  // Invoke npm to get the package name version.
+  const cmd = `npm view ${packageName} version`;
+  try {
+    const { stdout } = await shell(cmd);
+    // Obtain result from stdout splitting lines by new-line character
+    const stdoutLines = stdout.split('\n');
+    if (stdoutLines.length < 1) {
+      return { ok: false, msg: 'Version not provided by NPM', version: '' };
+    }
+
+    // Expect the version string to be in the first line of the standard
+    // output. Trim.
+    return { ok: true, msg: '', version: stdoutLines[0].trim() };
+  } catch (err) {
+    // Check for error 404 which means the package does not exist in the
+    // public registry.
+    const notExists = err.message.includes('ERR! 404');
+    if (notExists) {
+      msg = `Package ${packageName} is not in the NPM registry. A first version may be deployed`;
+      return { ok: true, msg, version: '' };
+    }
+
+    // NPM failed miserably...
+    return { ok: false, msg: err.message, version: '' };
+  }
+}
+
+/**
+ * Make version comparison (local/remote) to determine if the package can be
+ * merged and/or published to the NPM remote registry.
+ * @param {String} packageName
+ * @return {Object} { merge: boolean, publish: boolean }
+ */
+async function checkMergePublish() {
+  // Get package name and version from package.json.
+  const [pkgJsonName, pkgJsonVersion] = await getProjectNameAndVersion();
+
+  const { ok, msg, version } = await getPublishedVersion(pkgJsonName);
+  // The only condition to block merge to the target would be that the
+  // version specified in the package.json file is less than the one published
+  // in the NPM registry. In any other case, the merge will NOT be blocked.
+  // However, publish to NPM will ONLY be performed if the version in the
+  // package.json is greater than the latest version in registry or no version
+  // published there. In case of NPM failure, merge will still be possible,
+  // but no publish will be performed.
+  if (ok) {
+    if (version) {
+      ret = {
+        merge: pkgJsonVersion >= version,
+        publish: pkgJsonVersion > version,
+      };
+      if (!ret.merge) {
+        console.error(
+          `\nWILL NOT MERGE. Attempting to lower version. (Registry: ${version}, Local: ${pkgJsonVersion})`
+        );
+      }
+      if (!ret.publish) {
+        console.log(
+          `\nWill not publish. Local version should be higher. (Registry: ${version}, Local: ${pkgJsonVersion})`
+        );
+      }
+      return ret;
+    } else {
+      // Package not found in NPM registry. Will publish.
+      console.log(msg);
+      return {
+        merge: true,
+        publish: true,
+      };
+    }
+  }
+
+  // Not OK response from NPM (different from 404).
+  console.log(`\nWill not publish. Error with NPM`);
+  console.error(msg);
+  return {
+    merge: true,
+    publish: false,
+  };
+}
+
+async function main() {
+  const { merge, publish } = await checkMergePublish();
+  // Process exit code different from zero means merge will be blocked.
+  if (!merge) {
+    console.error('!!_DO_NOT_MERGE_!!');
+    // Exit abnormally.
+    process.exit(1);
+  }
+
+  if (publish) {
+    console.log('!!_DO_PUBLISH_!!');
+  } else {
+    console.log('!!_DO_NOT_PUBLISH_!!');
+  }
+}
+
+main();

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: BUILD SDK
 on: [pull_request]
 
 jobs:
-  deploy:
+  build:
     name: Build
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,9 @@ name: BUILD SDK
 on: [pull_request]
 
 jobs:
-  build:
+  deploy:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '10.18.1'
+      - name: Check local/remote pkg versions
+        run: node ./.github/willPublish.js
       - name: Installing dependencies
         run: yarn install
       - name: Building project

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,17 +14,17 @@ jobs:
         with:
           node-version: '10.18.1'
           registry-url: 'https://registry.npmjs.org'
+      - name: Evaluate package versions
+        id: will_publish
+        run: |
+          result=$(node ./.github/willPublish.js)
+          echo "::set-output name=RESULT::$result"
       - name: Installing dependencies
         run: yarn install
       - name: Building project
         run: yarn build
       - name: Running tests
         run: yarn test
-      - name: Evaluate package versions
-        id: will_publish
-        run: |
-          result=$(node ./.github/willPublish.js)
-          echo "::set-output name=RESULT::$result"
       - name: Publish to NPM
         if: ${{ endsWith(steps.will_publish.outputs.RESULT, '!!_DO_PUBLISH_!!') }}
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,34 @@
+name: PUBLISH
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    name: Publish to NPM
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.18.1'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Installing dependencies
+        run: yarn install
+      - name: Building project
+        run: yarn build
+      - name: Running tests
+        run: yarn test
+      - name: Evaluate package versions
+        id: will_publish
+        run: |
+          result=$(node ./.github/willPublish.js)
+          echo "::set-output name=RESULT::$result"
+      - name: Publish to NPM
+        if: ${{ endsWith(steps.will_publish.outputs.RESULT, '!!_DO_PUBLISH_!!') }}
+        run: |
+          npm config set scripts-prepend-node-path auto
+          yarn publish --non-interactive
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stablepay/sdk_l2",
-  "version": "0.0.24",
+  "version": "0.0.28",
   "description": "Official StablePay SDK for Ethereum Layer 2",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
Automate publishing to NPM registry checking pkg version

Publishing to NPM depends on the version number in the
local package.json vs published version in the NPM
public registry.

The only condition to block merge to the target branch
is that the version specified in the package.json file
is less than the one published in the NPM registry.
In any other case, the merge will NOT be blocked.
However, publish to NPM will ONLY be performed if the
version in the package.json is greater than the latest
version in the NPM registry or if no version is
published there.

In case of NPM failure, merge will still be possible,
but no publish will be performed.

Signed-off-by: Rodimiro Cerrato E <rodyce@gmail.com>