### PR TITLE
Disable Loopring L2 provider until further notice

### DIFF
--- a/src/Layer2Manager.ts
+++ b/src/Layer2Manager.ts
@@ -49,12 +49,6 @@ export class Layer2Manager {
             this.providerInstances.set(key, newProvider);
           }
           return this.providerInstances.get(key)!;
-        case Layer2Type.LOOPRING:
-          if (!this.providerInstances.has(key)) {
-            const newProvider = await getLoopringProvider(network);
-            this.providerInstances.set(key, newProvider);
-          }
-          return this.providerInstances.get(key)!;
       }
     } catch (err) {
       throw new Error(

--- a/src/loopring/LoopringLayer2Provider.ts
+++ b/src/loopring/LoopringLayer2Provider.ts
@@ -8,7 +8,7 @@ import axios from 'axios';
 export async function getLoopringProvider(
   network: 'localhost' | 'rinkeby' | 'ropsten' | 'mainnet' | 'goerli'
 ): Promise<Layer2Provider> {
-  return LoopringLayer2Provider.newInstance(network);
+  throw new Error("Loopring provider temporarily disabled");
 }
 
 export class TokenData {
@@ -17,7 +17,7 @@ export class TokenData {
     private _symbol: string,
     private _name: string,
     private _address: string
-  ) {}
+  ) { }
 
   get tokenId() {
     return this._tokenId;


### PR DESCRIPTION
It may be reenabled when these two conditions are met:
1. Ability to query balance without wallet onboarding
2. Ability to transfer coins to non-onboarded wallets

Signed-off-by: Rodimiro Cerrato E <rodyce@gmail.com>